### PR TITLE
Add Google OAuth2 strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'haml', '~> 4.0.4'
 gem 'bootstrap-sass', '~> 3.0.2.1'
 
 gem 'omniauth-github'
+gem 'omniauth-google-oauth2'
 gem 'omniauth-twitter'
 
 gem 'chartkick'

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
-  provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
+  provider :github,        ENV['GITHUB_KEY'],       ENV['GITHUB_SECRET']
+  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  provider :twitter,       ENV['TWITTER_KEY'],      ENV['TWITTER_SECRET']
+
   provider :developer unless Rails.env.production?
 end


### PR DESCRIPTION
Someone with access needs to get the client and token business set. Instructions from the README:

- Go to 'https://console.developers.google.com'
- Select your project.
- Click 'Enable and manage APIs'.
- Make sure "Contacts API" and "Google+ API" are on.
- Go to Credentials, then select the "OAuth consent screen" tab on top, and provide an 'EMAIL ADDRESS' and a 'PRODUCT NAME'
- Wait 10 minutes for changes to take effect.